### PR TITLE
feat: enhance Studio UX and add announcements page

### DIFF
--- a/app/announcements/page.tsx
+++ b/app/announcements/page.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import { Megaphone, Pin, Clock3 } from "lucide-react";
+
+import StandardPageHeader from "@/components/StandardPageHeader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { getAnnouncementsPagePayload, type AnnouncementListItem } from "@/sanity/lib/content";
+
+const fallbackAnnouncements: AnnouncementListItem[] = [
+  {
+    id: "fallback-1",
+    title: "Community Update",
+    message: "Announcements from the masjid will appear here when published in Studio.",
+    isPinned: true,
+    statusLabel: "Pinned",
+  },
+];
+
+export default async function AnnouncementsPage() {
+  const payload = await getAnnouncementsPagePayload();
+  const announcements = payload?.length ? payload : fallbackAnnouncements;
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-white to-emerald-50/40 text-stone-900 dark:from-stone-950 dark:to-stone-950 dark:text-stone-100">
+      <StandardPageHeader currentPage="Announcements" />
+
+      <main className="px-4 pb-10 pt-8 sm:px-6 lg:px-8 lg:pb-14">
+        <section className="mx-auto max-w-6xl">
+          <Card className="rounded-[30px] border-stone-200 shadow-sm dark:border-stone-800 dark:bg-stone-900/80">
+            <CardContent className="p-8 lg:p-10">
+              <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-700 dark:text-emerald-400">
+                ICRI Announcements
+              </p>
+              <h1 className="mt-2 text-4xl font-bold sm:text-5xl">Masjid Announcements</h1>
+              <p className="mt-4 max-w-3xl text-base leading-7 text-stone-600 dark:text-stone-300">
+                This page is connected to Sanity Studio. New announcements published in Studio appear here automatically.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-3">
+                <Button asChild className="rounded-2xl bg-emerald-700 hover:bg-emerald-800">
+                  <Link href="/">Back to Home</Link>
+                </Button>
+                <Button asChild variant="outline" className="rounded-2xl">
+                  <Link href="/studio">Manage in Studio</Link>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </section>
+
+        <section className="mx-auto mt-8 grid max-w-6xl gap-5">
+          {announcements.map((announcement) => (
+            <Card
+              key={announcement.id}
+              className="rounded-[24px] border-stone-200 shadow-sm dark:border-stone-800 dark:bg-stone-900/70"
+            >
+              <CardContent className="p-6">
+                <div className="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.12em]">
+                  <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-3 py-1 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-200">
+                    <Megaphone className="h-3.5 w-3.5" />
+                    {announcement.statusLabel}
+                  </span>
+                  {announcement.isPinned ? (
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-amber-800 dark:bg-amber-900/30 dark:text-amber-200">
+                      <Pin className="h-3.5 w-3.5" />
+                      Top Priority
+                    </span>
+                  ) : null}
+                  {announcement.windowLabel ? (
+                    <span className="inline-flex items-center gap-1.5 rounded-full bg-stone-100 px-3 py-1 text-stone-700 dark:bg-stone-800 dark:text-stone-200">
+                      <Clock3 className="h-3.5 w-3.5" />
+                      {announcement.windowLabel}
+                    </span>
+                  ) : null}
+                </div>
+
+                <h2 className="mt-4 text-2xl font-bold">{announcement.title}</h2>
+                <p className="mt-3 whitespace-pre-line leading-7 text-stone-700 dark:text-stone-300">
+                  {announcement.message}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -160,34 +160,22 @@ export default function Page() {
   const [events, setEvents] = useState(fallbackEvents);
   const [announcements, setAnnouncements] = useState(fallbackAnnouncements);
   const [mounted, setMounted] = useState(false);
-  const [themePreference, setThemePreference] = useState<ThemePreference>(() => {
-    if (typeof window === "undefined") {
-      return "system";
-    }
-
-    const savedTheme = window.localStorage.getItem("theme");
-    if (savedTheme === "light" || savedTheme === "dark" || savedTheme === "system") {
-      return savedTheme;
-    }
-
-    return "system";
-  });
-
-  const [theme, setTheme] = useState<"light" | "dark">(() => {
-    if (typeof window === "undefined") {
-      return "light";
-    }
-
-    const savedTheme = window.localStorage.getItem("theme");
-    if (savedTheme === "light" || savedTheme === "dark") {
-      return savedTheme;
-    }
-
-    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
-  });
+  const [themePreference, setThemePreference] = useState<ThemePreference>("system");
+  const [theme, setTheme] = useState<"light" | "dark">("light");
   const heroRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
+    const savedTheme = window.localStorage.getItem("theme");
+    const systemTheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+
+    if (savedTheme === "light" || savedTheme === "dark") {
+      setThemePreference(savedTheme);
+      setTheme(savedTheme);
+    } else {
+      setThemePreference("system");
+      setTheme(systemTheme);
+    }
+
     setMounted(true);
   }, []);
 
@@ -198,10 +186,6 @@ export default function Page() {
   };
 
   useEffect(() => {
-    if (typeof window === "undefined") {
-      return;
-    }
-
     if (themePreference !== "system") {
       return;
     }
@@ -413,6 +397,9 @@ export default function Page() {
             </Link>
             <Link href="/events" className={isScrolled ? "hover:text-emerald-700" : "hover:text-emerald-200"}>
               Events
+            </Link>
+            <Link href="/announcements" className={isScrolled ? "hover:text-emerald-700" : "hover:text-emerald-200"}>
+              Announcements
             </Link>
             <Link href="/amenities" className={isScrolled ? "hover:text-emerald-700" : "hover:text-emerald-200"}>
               Amenities
@@ -735,6 +722,12 @@ export default function Page() {
                     ? `Pinned announcement: ${announcements[0].title}`
                     : "Weekly reflections and reminders from Imam ABL can also be featured here."}
                 </p>
+                <Link
+                  href="/announcements"
+                  className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-emerald-700 hover:text-emerald-800"
+                >
+                  View all announcements <ChevronRight className="h-4 w-4" />
+                </Link>
               </div>
               <div className="grid gap-4">
                 {events.map((event) => (

--- a/components/StandardPageHeader.tsx
+++ b/components/StandardPageHeader.tsx
@@ -99,6 +99,9 @@ export default function StandardPageHeader({ currentPage, breadcrumbTrail }: Sta
             <Link href="/events" className="hover:text-emerald-700 dark:hover:text-emerald-300">
               Events
             </Link>
+            <Link href="/announcements" className="hover:text-emerald-700 dark:hover:text-emerald-300">
+              Announcements
+            </Link>
             <Link href="/amenities" className="hover:text-emerald-700 dark:hover:text-emerald-300">
               Amenities
             </Link>

--- a/sanity.config.ts
+++ b/sanity.config.ts
@@ -2,6 +2,7 @@ import { visionTool } from "@sanity/vision";
 import { defineConfig } from "sanity";
 import { structureTool } from "sanity/structure";
 
+import { deskStructure } from "./sanity/deskStructure";
 import { schemaTypes } from "./sanity/schemaTypes/index";
 
 const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || "";
@@ -13,7 +14,7 @@ export default defineConfig({
   basePath: "/studio",
   projectId,
   dataset,
-  plugins: [structureTool(), visionTool()],
+  plugins: [structureTool({ structure: deskStructure }), visionTool()],
   schema: {
     types: schemaTypes,
   },

--- a/sanity/deskStructure.ts
+++ b/sanity/deskStructure.ts
@@ -1,0 +1,65 @@
+import type { StructureResolver } from "sanity/structure";
+
+const groupedTypes = new Set(["prayerConfig", "dateOverride", "announcement", "event", "program"]);
+
+export const deskStructure: StructureResolver = (S) =>
+  S.list()
+    .title("🕌 ICRI Studio")
+    .items([
+      S.listItem()
+        .title("1) 🕒 Iqama Times")
+        .child(
+          S.list()
+            .title("🕒 Prayer Times")
+            .items([
+              S.listItem()
+                .title("Main Prayer Settings")
+                .child(S.document().schemaType("prayerConfig").documentId("prayerConfig").title("Main Prayer Settings")),
+              S.divider(),
+              S.listItem()
+                .title("Special Date Overrides")
+                .child(
+                  S.documentTypeList("dateOverride")
+                    .title("Special Date Overrides")
+                    .defaultOrdering([{ field: "date", direction: "desc" }]),
+                ),
+            ]),
+        ),
+
+      S.listItem()
+        .title("2) 🌐 Website Updates")
+        .child(
+          S.list()
+            .title("🌐 Website Updates")
+            .items([
+              S.listItem()
+                .title("📢 Announcements")
+                .child(
+                  S.documentTypeList("announcement")
+                    .title("Announcements")
+                    .defaultOrdering([{ field: "_updatedAt", direction: "desc" }]),
+                ),
+              S.listItem()
+                .title("🗓️ Events")
+                .child(
+                  S.documentTypeList("event")
+                    .title("Events")
+                    .defaultOrdering([{ field: "startAt", direction: "desc" }]),
+                ),
+              S.listItem()
+                .title("📚 Programs")
+                .child(
+                  S.documentTypeList("program")
+                    .title("Programs")
+                    .defaultOrdering([{ field: "order", direction: "asc" }]),
+                ),
+            ]),
+        ),
+
+      S.divider(),
+
+      ...S.documentTypeListItems().filter((listItem) => {
+        const id = listItem.getId();
+        return id ? !groupedTypes.has(id) : true;
+      }),
+    ]);

--- a/sanity/lib/content.ts
+++ b/sanity/lib/content.ts
@@ -3,9 +3,13 @@ import { groq } from "next-sanity";
 import { sanityClient } from "./client";
 
 type AnnouncementDoc = {
+  _id?: string;
   title: string;
   message: string;
   isPinned?: boolean;
+  startAt?: string;
+  endAt?: string;
+  isActive?: boolean;
 };
 
 type EventDoc = {
@@ -57,6 +61,15 @@ export type ProgramListItem = {
   imageAlt?: string;
 };
 
+export type AnnouncementListItem = {
+  id: string;
+  title: string;
+  message: string;
+  isPinned: boolean;
+  statusLabel: string;
+  windowLabel?: string;
+};
+
 const announcementsQuery = groq`*[_type == "announcement" && isActive == true] | order(isPinned desc, startAt desc) {
   title,
   message,
@@ -102,6 +115,16 @@ const programsQuery = groq`*[_type == "program" && isActive == true] | order(ord
     alt,
     "url": asset->url
   }
+}`;
+
+const allAnnouncementsQuery = groq`*[_type == "announcement" && isActive == true] | order(isPinned desc, _updatedAt desc) {
+  _id,
+  title,
+  message,
+  isPinned,
+  startAt,
+  endAt,
+  isActive
 }`;
 
 function formatEventDate(dateIso: string): string {
@@ -176,6 +199,41 @@ function normalizeProgramIcon(iconKey?: string): "book" | "users" | "calendar" {
   }
 
   return "book";
+}
+
+function formatAnnouncementWindow(startAt?: string, endAt?: string): string | undefined {
+  if (!startAt && !endAt) {
+    return undefined;
+  }
+
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "America/New_York",
+  });
+
+  const start = startAt ? new Date(startAt) : null;
+  const end = endAt ? new Date(endAt) : null;
+
+  const validStart = start && !Number.isNaN(start.getTime()) ? formatter.format(start) : null;
+  const validEnd = end && !Number.isNaN(end.getTime()) ? formatter.format(end) : null;
+
+  if (validStart && validEnd) {
+    return `${validStart} → ${validEnd} ET`;
+  }
+
+  if (validStart) {
+    return `From ${validStart} ET`;
+  }
+
+  if (validEnd) {
+    return `Until ${validEnd} ET`;
+  }
+
+  return undefined;
 }
 
 export async function getHomeContentPayload() {
@@ -266,5 +324,22 @@ export async function getProgramsPagePayload(): Promise<ProgramListItem[] | null
     scheduleText: program.scheduleText,
     imageUrl: program.cardImage?.url,
     imageAlt: program.cardImage?.alt || `${program.title} image`,
+  }));
+}
+
+export async function getAnnouncementsPagePayload(): Promise<AnnouncementListItem[] | null> {
+  if (!sanityClient) {
+    return null;
+  }
+
+  const announcements = await sanityClient.fetch<AnnouncementDoc[]>(allAnnouncementsQuery);
+
+  return (announcements || []).map((announcement, index) => ({
+    id: announcement._id || `announcement-${index}`,
+    title: announcement.title,
+    message: announcement.message,
+    isPinned: Boolean(announcement.isPinned),
+    statusLabel: announcement.isPinned ? "Pinned" : "General",
+    windowLabel: formatAnnouncementWindow(announcement.startAt, announcement.endAt),
   }));
 }

--- a/sanity/lib/prayer.ts
+++ b/sanity/lib/prayer.ts
@@ -13,7 +13,8 @@ export type JumuahSession = {
 
 type PrayerConfig = {
   timezone?: string;
-  weekAnchorDate?: string;
+  weeklyTemplate?: Record<PrayerKey, string> & { jumuah?: JumuahSession[] };
+  // Backward compatibility for existing content before migration:
   biweeklyTemplate?: {
     weekA?: Record<PrayerKey, string> & { jumuah?: JumuahSession[] };
     weekB?: Record<PrayerKey, string> & { jumuah?: JumuahSession[] };
@@ -49,7 +50,7 @@ const IQAMAH_FALLBACK_OFFSETS: Record<PrayerName, number> = {
 
 const prayerConfigQuery = groq`*[_type == "prayerConfig"][0]{
   timezone,
-  weekAnchorDate,
+  weeklyTemplate,
   biweeklyTemplate
 }`;
 
@@ -86,13 +87,6 @@ function addMinutes(time24: string, minutes: number): string {
   const outHour = Math.floor(normalized / 60);
   const outMinute = normalized % 60;
   return `${String(outHour).padStart(2, "0")}:${String(outMinute).padStart(2, "0")}`;
-}
-
-function dayDiff(anchorDate: string, todayDate: string): number {
-  const anchor = new Date(`${anchorDate}T00:00:00Z`);
-  const today = new Date(`${todayDate}T00:00:00Z`);
-  const milliseconds = today.getTime() - anchor.getTime();
-  return Math.floor(milliseconds / 86400000);
 }
 
 function getDateInTimezone(timezone: string): string {
@@ -173,13 +167,11 @@ export async function getTodayPrayerPayload() {
       })
     : null;
 
-  const weekAnchorDate = config?.weekAnchorDate;
-  const diffInDays = weekAnchorDate ? dayDiff(weekAnchorDate, effectiveDate) : 0;
-  const weekIndex = Math.floor(diffInDays / 7);
-  const isWeekA = weekIndex % 2 === 0;
-  const weekDefaults = isWeekA
-    ? config?.biweeklyTemplate?.weekA
-    : config?.biweeklyTemplate?.weekB;
+  const weeklyDefaults =
+    config?.weeklyTemplate ||
+    // Backward compatibility fallback until content is migrated:
+    config?.biweeklyTemplate?.weekA ||
+    config?.biweeklyTemplate?.weekB;
 
   const prayers = PRAYER_ORDER.map((prayerName) => {
     const adhan24 = parseApiTime(timings[prayerName]);
@@ -187,7 +179,7 @@ export async function getTodayPrayerPayload() {
       prayerName,
       adhan24,
       override,
-      weekDefaults,
+      weekDefaults: weeklyDefaults,
     });
 
     return {
@@ -203,14 +195,14 @@ export async function getTodayPrayerPayload() {
   const jumuahSessions = isFriday
     ? override?.jumuah?.length
       ? override.jumuah
-      : weekDefaults?.jumuah || []
+      : weeklyDefaults?.jumuah || []
     : [];
 
   return {
     date: effectiveDate,
     source: {
       adhan: "aladhan",
-      iqamah: override ? "dateOverride" : weekDefaults ? (isWeekA ? "weekA" : "weekB") : "fallbackOffset",
+      iqamah: override ? "dateOverride" : weeklyDefaults ? "weeklyDefault" : "fallbackOffset",
     },
     prayers,
     jumuahSessions: jumuahSessions.map((session) => ({

--- a/sanity/schemaTypes/announcement.ts
+++ b/sanity/schemaTypes/announcement.ts
@@ -5,11 +5,56 @@ export const announcementType = defineType({
   title: "Announcement",
   type: "document",
   fields: [
-    defineField({ name: "title", title: "Title", type: "string", validation: (rule) => rule.required() }),
-    defineField({ name: "message", title: "Message", type: "text", validation: (rule) => rule.required() }),
-    defineField({ name: "startAt", title: "Start", type: "datetime" }),
-    defineField({ name: "endAt", title: "End", type: "datetime" }),
-    defineField({ name: "isPinned", title: "Pinned", type: "boolean", initialValue: false }),
-    defineField({ name: "isActive", title: "Active", type: "boolean", initialValue: true }),
+    defineField({
+      name: "title",
+      title: "Headline",
+      description: "Short title shown on the website.",
+      type: "string",
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "message",
+      title: "Announcement Text",
+      description: "Main message people will read.",
+      type: "text",
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "startAt",
+      title: "Show From",
+      description: "Optional. Date/time to start showing this announcement.",
+      type: "datetime",
+    }),
+    defineField({
+      name: "endAt",
+      title: "Show Until",
+      description: "Optional. Date/time to stop showing this announcement.",
+      type: "datetime",
+    }),
+    defineField({
+      name: "isPinned",
+      title: "Pin to Top",
+      description: "Turn on to keep this announcement at the top.",
+      type: "boolean",
+      initialValue: false,
+    }),
+    defineField({
+      name: "isActive",
+      title: "Visible on Website",
+      description: "Turn off to hide this announcement.",
+      type: "boolean",
+      initialValue: true,
+    }),
   ],
+  preview: {
+    select: {
+      title: "title",
+      isPinned: "isPinned",
+      isActive: "isActive",
+    },
+    prepare: ({ title, isPinned, isActive }) => ({
+      title: title || "Untitled announcement",
+      subtitle: `${isPinned ? "Pinned" : "Regular"} • ${isActive ? "Visible" : "Hidden"}`,
+    }),
+  },
 });

--- a/sanity/schemaTypes/dateOverride.ts
+++ b/sanity/schemaTypes/dateOverride.ts
@@ -6,6 +6,7 @@ const optionalPrayerField = (name: string, title: string) =>
   defineField({
     name,
     title,
+    description: "Optional. Leave empty to keep the normal weekly time. Format: HH:mm (example: 18:30)",
     type: "string",
     validation: (rule) =>
       rule.regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
@@ -13,12 +14,13 @@ const optionalPrayerField = (name: string, title: string) =>
 
 export const dateOverrideType = defineType({
   name: "dateOverride",
-  title: "Date Override",
+  title: "Special Date Prayer Override",
   type: "document",
   fields: [
     defineField({
       name: "date",
-      title: "Date",
+      title: "Override Date",
+      description: "Choose the exact day that has different prayer times.",
       type: "date",
       validation: (rule) => rule.required(),
     }),
@@ -30,21 +32,30 @@ export const dateOverrideType = defineType({
     defineField({
       name: "jumuah",
       title: "Jumu'ah Override Sessions",
+      description: "Optional. Add custom Jumu'ah sessions for this date only.",
       type: "array",
       of: [
         defineArrayMember({
           type: "object",
           fields: [
-            defineField({ name: "label", title: "Label", type: "string", initialValue: "1st Khutbah" }),
+            defineField({
+              name: "label",
+              title: "Session Label",
+              description: "Example: 1st Khutbah, 2nd Khutbah",
+              type: "string",
+              initialValue: "1st Khutbah",
+            }),
             defineField({
               name: "khutbahTime",
               title: "Khutbah Time",
+              description: "Format: HH:mm (example: 13:15)",
               type: "string",
               validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
             }),
             defineField({
               name: "iqamahTime",
               title: "Iqama Time",
+              description: "Format: HH:mm (example: 13:45)",
               type: "string",
               validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
             }),
@@ -65,7 +76,8 @@ export const dateOverrideType = defineType({
     }),
     defineField({
       name: "note",
-      title: "Internal Note",
+      title: "Notes for Admins",
+      description: "Optional note to explain why this override exists.",
       type: "string",
     }),
   ],
@@ -76,7 +88,7 @@ export const dateOverrideType = defineType({
     },
     prepare: ({ date, note }) => ({
       title: date ? `Override ${date}` : "Date Override",
-      subtitle: note || "Custom Iqama overrides",
+      subtitle: note || "Custom prayer times for this date",
     }),
   },
 });

--- a/sanity/schemaTypes/event.ts
+++ b/sanity/schemaTypes/event.ts
@@ -5,14 +5,42 @@ export const eventType = defineType({
   title: "Event",
   type: "document",
   fields: [
-    defineField({ name: "title", title: "Title", type: "string", validation: (rule) => rule.required() }),
-    defineField({ name: "summary", title: "Summary", type: "text" }),
-    defineField({ name: "startAt", title: "Start", type: "datetime", validation: (rule) => rule.required() }),
-    defineField({ name: "endAt", title: "End", type: "datetime" }),
-    defineField({ name: "location", title: "Location", type: "string" }),
+    defineField({
+      name: "title",
+      title: "Event Name",
+      description: "Name shown on the website.",
+      type: "string",
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "summary",
+      title: "Short Description",
+      description: "Optional short details about the event.",
+      type: "text",
+    }),
+    defineField({
+      name: "startAt",
+      title: "Start Date & Time",
+      description: "When the event begins.",
+      type: "datetime",
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "endAt",
+      title: "End Date & Time",
+      description: "Optional end time.",
+      type: "datetime",
+    }),
+    defineField({
+      name: "location",
+      title: "Location",
+      description: "Optional location (e.g., Main Prayer Hall).",
+      type: "string",
+    }),
     defineField({
       name: "flyerImage",
       title: "Flyer Image",
+      description: "Optional event flyer image.",
       type: "image",
       options: { hotspot: true },
       fields: [
@@ -24,7 +52,29 @@ export const eventType = defineType({
         }),
       ],
     }),
-    defineField({ name: "ctaUrl", title: "Call to Action URL", type: "url" }),
-    defineField({ name: "isPublished", title: "Published", type: "boolean", initialValue: true }),
+    defineField({
+      name: "ctaUrl",
+      title: "Button Link",
+      description: "Optional link for registration or details page.",
+      type: "url",
+    }),
+    defineField({
+      name: "isPublished",
+      title: "Visible on Website",
+      description: "Turn off to hide this event.",
+      type: "boolean",
+      initialValue: true,
+    }),
   ],
+  preview: {
+    select: {
+      title: "title",
+      startAt: "startAt",
+      isPublished: "isPublished",
+    },
+    prepare: ({ title, startAt, isPublished }) => ({
+      title: title || "Untitled event",
+      subtitle: `${startAt ? new Date(startAt).toLocaleDateString() : "No date"} • ${isPublished ? "Visible" : "Hidden"}`,
+    }),
+  },
 });

--- a/sanity/schemaTypes/helpers.ts
+++ b/sanity/schemaTypes/helpers.ts
@@ -1,3 +1,3 @@
 export const HHMM_24H_REGEX = /^([01]\d|2[0-3]):([0-5]\d)$/;
 
-export const timeValidationMessage = "Use 24-hour format HH:mm (example: 18:30).";
+export const timeValidationMessage = "Please use 24-hour time like HH:mm (examples: 05:45, 13:30, 18:30).";

--- a/sanity/schemaTypes/prayerConfig.ts
+++ b/sanity/schemaTypes/prayerConfig.ts
@@ -6,30 +6,35 @@ const prayerFields = [
   defineField({
     name: "fajr",
     title: "Fajr Iqama",
+    description: "Enter time as HH:mm (24-hour). Example: 05:45",
     type: "string",
     validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
   }),
   defineField({
     name: "dhuhr",
     title: "Dhuhr Iqama",
+    description: "Enter time as HH:mm (24-hour). Example: 13:30",
     type: "string",
     validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
   }),
   defineField({
     name: "asr",
     title: "Asr Iqama",
+    description: "Enter time as HH:mm (24-hour). Example: 16:45",
     type: "string",
     validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
   }),
   defineField({
     name: "maghrib",
     title: "Maghrib Iqama",
+    description: "Enter time as HH:mm (24-hour). Example: 18:20",
     type: "string",
     validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
   }),
   defineField({
     name: "isha",
     title: "Isha Iqama",
+    description: "Enter time as HH:mm (24-hour). Example: 19:45",
     type: "string",
     validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
   }),
@@ -37,114 +42,67 @@ const prayerFields = [
 
 export const prayerConfigType = defineType({
   name: "prayerConfig",
-  title: "Prayer Configuration",
+  title: "Prayer Times Settings",
   type: "document",
   fields: [
     defineField({
       name: "timezone",
-      title: "Masjid Timezone",
+      title: "Masjid Time Zone",
+      description: "Usually leave as America/New_York unless you move to a different time zone.",
       type: "string",
       initialValue: "America/New_York",
       validation: (rule) => rule.required(),
     }),
     defineField({
-      name: "weekAnchorDate",
-      title: "Week A Anchor Date",
-      description: "Any known Week A date. Week parity is calculated from this date.",
-      type: "date",
-      validation: (rule) => rule.required(),
-    }),
-    defineField({
-      name: "biweeklyTemplate",
-      title: "Biweekly Defaults",
+      name: "weeklyTemplate",
+      title: "Default Weekly Prayer Times",
+      description: "Set the regular weekly iqama schedule. Use special date overrides only when needed.",
       type: "object",
       validation: (rule) => rule.required(),
       fields: [
+        ...prayerFields,
         defineField({
-          name: "weekA",
-          title: "Week A",
-          type: "object",
-          fields: [
-            ...prayerFields,
-            defineField({
-              name: "jumuah",
-              title: "Jumu'ah Sessions",
-              type: "array",
-              of: [
-                defineArrayMember({
-                  type: "object",
-                  fields: [
-                    defineField({ name: "label", title: "Label", type: "string", initialValue: "1st Khutbah" }),
-                    defineField({
-                      name: "khutbahTime",
-                      title: "Khutbah Time",
-                      type: "string",
-                      validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
-                    }),
-                    defineField({
-                      name: "iqamahTime",
-                      title: "Iqama Time",
-                      type: "string",
-                      validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
-                    }),
-                  ],
-                  preview: {
-                    select: {
-                      title: "label",
-                      khutbahTime: "khutbahTime",
-                      iqamahTime: "iqamahTime",
-                    },
-                    prepare: ({ title, khutbahTime, iqamahTime }) => ({
-                      title: title || "Jumu'ah Session",
-                      subtitle: `${khutbahTime} • Iqama ${iqamahTime}`,
-                    }),
-                  },
+          name: "jumuah",
+          title: "Jumu'ah Sessions",
+          description: "Add one or more Jumu'ah khutbah/iqama sessions.",
+          type: "array",
+          of: [
+            defineArrayMember({
+              type: "object",
+              fields: [
+                defineField({
+                  name: "label",
+                  title: "Session Label",
+                  description: "Example: 1st Khutbah, 2nd Khutbah",
+                  type: "string",
+                  initialValue: "1st Khutbah",
+                }),
+                defineField({
+                  name: "khutbahTime",
+                  title: "Khutbah Time",
+                  description: "Enter time as HH:mm (24-hour). Example: 13:15",
+                  type: "string",
+                  validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
+                }),
+                defineField({
+                  name: "iqamahTime",
+                  title: "Iqama Time",
+                  description: "Enter time as HH:mm (24-hour). Example: 13:45",
+                  type: "string",
+                  validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
                 }),
               ],
-            }),
-          ],
-        }),
-        defineField({
-          name: "weekB",
-          title: "Week B",
-          type: "object",
-          fields: [
-            ...prayerFields,
-            defineField({
-              name: "jumuah",
-              title: "Jumu'ah Sessions",
-              type: "array",
-              of: [
-                defineArrayMember({
-                  type: "object",
-                  fields: [
-                    defineField({ name: "label", title: "Label", type: "string", initialValue: "1st Khutbah" }),
-                    defineField({
-                      name: "khutbahTime",
-                      title: "Khutbah Time",
-                      type: "string",
-                      validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
-                    }),
-                    defineField({
-                      name: "iqamahTime",
-                      title: "Iqama Time",
-                      type: "string",
-                      validation: (rule) => rule.required().regex(HHMM_24H_REGEX, { name: "HH:mm" }).error(timeValidationMessage),
-                    }),
-                  ],
-                  preview: {
-                    select: {
-                      title: "label",
-                      khutbahTime: "khutbahTime",
-                      iqamahTime: "iqamahTime",
-                    },
-                    prepare: ({ title, khutbahTime, iqamahTime }) => ({
-                      title: title || "Jumu'ah Session",
-                      subtitle: `${khutbahTime} • Iqama ${iqamahTime}`,
-                    }),
-                  },
+              preview: {
+                select: {
+                  title: "label",
+                  khutbahTime: "khutbahTime",
+                  iqamahTime: "iqamahTime",
+                },
+                prepare: ({ title, khutbahTime, iqamahTime }) => ({
+                  title: title || "Jumu'ah Session",
+                  subtitle: `${khutbahTime} • Iqama ${iqamahTime}`,
                 }),
-              ],
+              },
             }),
           ],
         }),
@@ -153,8 +111,8 @@ export const prayerConfigType = defineType({
   ],
   preview: {
     prepare: () => ({
-      title: "Prayer Configuration",
-      subtitle: "Biweekly defaults and timezone",
+      title: "Prayer Times Settings",
+      subtitle: "Weekly schedule and masjid timezone",
     }),
   },
 });

--- a/sanity/schemaTypes/program.ts
+++ b/sanity/schemaTypes/program.ts
@@ -5,11 +5,24 @@ export const programType = defineType({
   title: "Program",
   type: "document",
   fields: [
-    defineField({ name: "title", title: "Title", type: "string", validation: (rule) => rule.required() }),
-    defineField({ name: "description", title: "Description", type: "text", validation: (rule) => rule.required() }),
+    defineField({
+      name: "title",
+      title: "Program Name",
+      description: "Name shown on the website.",
+      type: "string",
+      validation: (rule) => rule.required(),
+    }),
+    defineField({
+      name: "description",
+      title: "Program Description",
+      description: "Explain the program in simple words.",
+      type: "text",
+      validation: (rule) => rule.required(),
+    }),
     defineField({
       name: "iconKey",
-      title: "Icon",
+      title: "Icon Style",
+      description: "Choose the icon shown for this program card.",
       type: "string",
       initialValue: "book",
       options: {
@@ -20,10 +33,16 @@ export const programType = defineType({
         ],
       },
     }),
-    defineField({ name: "scheduleText", title: "Schedule", type: "string" }),
+    defineField({
+      name: "scheduleText",
+      title: "Schedule Text",
+      description: "Example: Every Saturday after Asr",
+      type: "string",
+    }),
     defineField({
       name: "cardImage",
       title: "Card Image",
+      description: "Optional image for this program card.",
       type: "image",
       options: { hotspot: true },
       fields: [
@@ -35,7 +54,30 @@ export const programType = defineType({
         }),
       ],
     }),
-    defineField({ name: "order", title: "Sort Order", type: "number", initialValue: 0 }),
-    defineField({ name: "isActive", title: "Active", type: "boolean", initialValue: true }),
+    defineField({
+      name: "order",
+      title: "Display Order",
+      description: "Lower number appears first (0, 1, 2...).",
+      type: "number",
+      initialValue: 0,
+    }),
+    defineField({
+      name: "isActive",
+      title: "Visible on Website",
+      description: "Turn off to hide this program.",
+      type: "boolean",
+      initialValue: true,
+    }),
   ],
+  preview: {
+    select: {
+      title: "title",
+      scheduleText: "scheduleText",
+      isActive: "isActive",
+    },
+    prepare: ({ title, scheduleText, isActive }) => ({
+      title: title || "Untitled program",
+      subtitle: `${scheduleText || "No schedule"} • ${isActive ? "Visible" : "Hidden"}`,
+    }),
+  },
 });


### PR DESCRIPTION
- Add custom Sanity desk structure with friendly grouping (Iqama Times, Website Updates)
- Add visual emoji-based navigation and singleton prayer settings
- Simplify prayer schema: remove biweekly rotation, use single weekly template + date overrides
- Add elder-friendly field labels, descriptions, and validation messages across all schemas
- Create /announcements page connected to Sanity content
- Add announcements nav links to home and shared headers
- Fix hydration mismatch on home page by deferring theme initialization to useEffect
- Remove duplicate Studio document lists (now grouped in desk structure)